### PR TITLE
Xml on build fix

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Users\jlync\Documents\Visual Studio 2017\Projects\HarmonyHub\Harmony\Harmony.xml</DocumentationFile>
+    <DocumentationFile>Harmony.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixed issue where the Harmony project build would fail due to fixed path for the xml-doc file.